### PR TITLE
Update Cargo.toml add repository

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT"
 keywords = ["template", "cli", "json", "yaml", "hcl"]
 categories = ["command-line-utilities", "template-engine", "development-tools"]
 exclude = [".github"]
+repository = "https://github.com/hiddewie/template"
 
 [dependencies]
 serde_json = "1.0"


### PR DESCRIPTION
to allow crates.io, rust-digger, and others to link to it.